### PR TITLE
Change repository url from SSH to HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "bin": "./scripts/harp-fontcatalog-generator.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/heremaps/harp-fontcatalog-generator.git"
+    "url": "https://github.com/heremaps/harp-fontcatalog-generator.git"
   },
   "author": {
     "name": "HERE Europe B.V.",


### PR DESCRIPTION
Using HTTPS allows users to clone the repository using
tools like OSS Review Toolkit without authentication.
